### PR TITLE
Updates to the book section in apps/views/pages/_links.html.slim

### DIFF
--- a/app/views/pages/_links.html.slim
+++ b/app/views/pages/_links.html.slim
@@ -62,40 +62,129 @@ ul
 
 h2#books Ruby Books
 
+h3#beginner New to Ruby?
+
 ul
   li
     a href="https://pine.fm/LearnToProgram/"
       | Learn to Program (Ruby version)
+
   li
     a href="http://learnrubythehardway.org/book/"
       | Learn Ruby the Hard Way
+
   li
     a href="http://ruby-doc.com/docs/ProgrammingRuby/"
       | Programming Ruby
-  li
-    a href="https://www.railstutorial.org/book"
-      | Ruby on Rails Tutorial
-  li
-    a href="http://mislav.uniqpath.com/poignant-guide/book/chapter-1.html"
-      | _why's Poignant Guide to Ruby
-  li
-    a href="http://humblelittlerubybook.com"
-      | Mr. Neighborly's Humble Little Ruby Book
 
   li
-    a href="https://www.manning.com/books/the-well-grounded-rubyist-second-edition"
-      | The Well-Grounded Rubyist, Second Edition (aka Black's Book)
+    a href="https://www.amazon.com/Head-First-Ruby-Brain-Friendly-Guide/dp/1449372651"
+      | Head First Ruby
 
+  li
+    a href="https://baweaver.gitbooks.io/an-illustrated-guide-to-ruby/content/"
+      | An Illustrated Guide to Ruby
+
+  li
+    a href="https://www.manning.com/books/the-well-grounded-rubyist-third-edition"
+      | The Well-Grounded Rubyist, Third Edition (aka Black's Book)
+
+  li
+    a href="https://www.amazon.com/Ruby-Programming-Language-Everything-Need/dp/0596516177"
+      | The Ruby Programming Language
+
+
+h3#journeyman Ready to do stuff with Ruby?
+
+ul 
   li
     a href="http://eloquentruby.com/"
       | Eloquent Ruby
+
+  li
+    a href="https://www.amazon.com/Ruby-Best-Practices-Increase-Productivity/dp/0596523009"
+      | Ruby Best Practices
+
+  li
+    a href="https://www.amazon.com/Ruby-Cookbook-Recipes-Object-Oriented-Scripting/dp/1449373712"
+      | Ruby Cookbook
+
+  li
+    a href="https://www.amazon.com/Effective-Testing-RSpec-Build-Confidence/dp/1680501984"
+      | Effective Testing with RSpec 3
+
+  li
+    a href="https://chriskottom.com/minitestcookbook/"
+      | The Minitest Cookbook
+
+  li
+    a href="https://www.amazon.com/Build-Awesome-Command-Line-Applications-Ruby/dp/1937785750"
+      | Building Awesome Command-Line Applications in Ruby 2
 
   li
     a href="http://www.sandimetz.com/products/"
       | Practical Object-Oriented Design in Ruby (POODR)
 
   li
-    a href="http://www.confidentruby.com/"
+    a href="https://pragprog.com/titles/agcr/confident-ruby/"
       | Confident Ruby
+
+  li
+    a href="https://pragprog.com/titles/ager/exceptional-ruby/"
+      | Exceptional Ruby
+
+  li
+    a href="https://www.amazon.com/Design-Patterns-Ruby-Russ-Olsen/dp/0321490452"
+      | Design Patterns in Ruby
+
+  li
+    a href="https://www.amazon.com/Wicked-Cool-Ruby-Scripts-Steve-ebook/dp/B002N3M6SG"
+      | Wicked Cool Ruby Scripts
+
+  li
+    a href="https://www.amazon.com/Ruby-Way-Programming-Addison-Wesley-Professional/dp/0321714636"
+      | The Ruby Way
+
+  li
+    a href="https://www.amazon.com/Sinatra-Running-Ruby-Web-Simply/dp/1449304230"
+      | Sinatra Up and Running
+ 
+  li
+    a href="https://www.amazon.com/Clean-Ruby-Crafting-Better-Rubyists/dp/1484255453"
+      | Clean Ruby
+
+  li
+    a href="https://www.amazon.com/Mastering-Regular-Expressions-Jeffrey-Friedl/dp/0596528124"
+      | Mastering Regular Expressions
+
+
+h3#advanced Deep into Ruby?
+
+ul
+  li
+    a href="https://www.amazon.com/Ruby-Under-Microscope-Illustrated-Internals-ebook/dp/B00GK5P6L2"
+      | Ruby Under a Microscope
+
+  li
+    a href="https://www.amazon.com/Understanding-Computation-Machines-Impossible-Programs-ebook/dp/B00CT3C4IM"
+      | Understanding Computation
+
+  li
+    a href="https://www.amazon.com/Metaprogramming-Ruby-Program-Like-Facets/dp/1941222129"
+      | Metaprogramming Ruby
+
+  li
+    a href="https://leanpub.com/combinators"
+      | Kestrels, Quirky Birds, and Hopeless Egocentricity
+
+  li
+    a href="https://pragprog.com/titles/adrpo/ruby-performance-optimization/"
+      | Ruby Performance Optimization
+
+  li
+    a href="https://www.amazon.com/Refactoring-Ruby-Addison-Wesley-Professional/dp/0321984137"
+      | Refactoring: Ruby Edition
+
+
 
 p Your website is not listed here? Contact us in the #ruby channel on freenode.net. Any of #{Rails.application.config.contributors.join(', ')} will gladly help


### PR DESCRIPTION
Removed Why's guide, link did not work.
Removed Humble Little Ruby Book, link broken.
Updated Black's book to 3rd edition.
Changed the Confident Ruby to the PraProg site.
Added Sections, based on reader Ruby skills.
Did not add "Text Processing with Ruby" as it's no longer on the PragProg site, and $70 on Amazon. Sent PragProg a note to see if they will be coming out with a new one.
Removed the Rails Tutorial, since there's lots of Rails stuff. Is there a "Rails_community"?   :)
Added several books.